### PR TITLE
Remove breaking calls to getViewportWidget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.27'
+def runeLiteVersion = '1.6.35'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/begosrs/barbarianassault/grounditems/GroundItemsOverlay.java
+++ b/src/main/java/begosrs/barbarianassault/grounditems/GroundItemsOverlay.java
@@ -164,7 +164,7 @@ public class GroundItemsOverlay extends OverlayPanel
 	{
 		final Player player = client.getLocalPlayer();
 
-		if (player == null || client.getViewportWidget() == null)
+		if (player == null)
 		{
 			return;
 		}

--- a/src/main/java/begosrs/barbarianassault/hoppers/HoppersOverlay.java
+++ b/src/main/java/begosrs/barbarianassault/hoppers/HoppersOverlay.java
@@ -85,7 +85,7 @@ public class HoppersOverlay extends Overlay
 		}
 
 		final Player player = client.getLocalPlayer();
-		if (player == null || client.getViewportWidget() == null)
+		if (player == null)
 		{
 			return null;
 		}


### PR DESCRIPTION
With the newest version of runelite, this plugin causes the client to crash in BA when activated, as the method `client.getViewportWidget()` is no longer defined in the client api. See Adam's issue on the topic:  #2.

The fix seems to work fine, but was only briefly tested (crash did not occur at start of BA game and overlays seems fine).
